### PR TITLE
Spike vexflow

### DIFF
--- a/src/AnswerOptions.js
+++ b/src/AnswerOptions.js
@@ -1,0 +1,41 @@
+import { Flow } from 'vexflow';
+var { GhostNote } = Flow;
+
+export default class AnswerOptions extends GhostNote {
+  draw() {
+    var group = this.context.openGroup('answer-options', this.getAttribute('id'));
+    this.setAttribute('el', group);
+
+    this.drawNote('g/3');
+    this.drawNote('a/3');
+    this.drawNote('b/3');
+    this.drawNote('c/4');
+    this.drawNote('d/4');
+    this.drawNote('e/4');
+    this.drawNote('f/4');
+    this.drawNote('g/4');
+    this.drawNote('a/4');
+    this.drawNote('b/4');
+    this.drawNote('c/5');
+    this.drawNote('d/5');
+    this.drawNote('e/5');
+    this.drawNote('f/5');
+
+    this.context.closeGroup();
+    this.setRendered();
+  }
+
+  drawNote(pitch) {
+    var note = new Flow.StaveNote({ keys: [pitch], stem_direction: 1, duration: '4' });
+    this.tickContext.addTickable(note);
+    note.setContext(this.context).setStave(this.getStave());
+
+    const optionGroup = this.context.openGroup();
+    console.log(optionGroup);
+    note.draw();
+    this.context.closeGroup();
+    optionGroup.classList.add('option-question-tempo-4-duration-4-note-C');
+    optionGroup.classList.add('option-question');
+    optionGroup.addEventListener('click', () => { console.log('clicked on ', pitch) })
+  }
+}

--- a/src/AnswerOptions.js
+++ b/src/AnswerOptions.js
@@ -23,6 +23,10 @@ export default class AnswerOptions extends GhostNote {
 
     this.context.closeGroup();
     this.setRendered();
+
+    this.group = group;
+    console.log('group', group.id);
+    console.log('parent', group.parent);
   }
 
   drawNote(pitch) {
@@ -37,5 +41,9 @@ export default class AnswerOptions extends GhostNote {
     optionGroup.classList.add('option-question-tempo-4-duration-4-note-C');
     optionGroup.classList.add('option-question');
     optionGroup.addEventListener('click', () => { console.log('clicked on ', pitch) })
+  }
+
+  remove() {
+    this.group.remove()
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -22,6 +22,16 @@
   fill: rgba(12,12,12, 0.2);
 }
 
+.option-question {
+  fill: transparent;
+  stroke: transparent;
+}
+
+.option-question:hover {
+  fill: rgba(0,0,0,0.5);
+  stroke: rgba(0,0,0,0.5);
+}
+
 .App {
   text-align: center;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -13,6 +13,14 @@
     fill: blue;
 }
 
+.layer-highlight rect {
+  fill: transparent;
+  stroke: transparent;
+}
+
+.layer-highlight rect:hover {
+  fill: rgba(12,12,12, 0.2);
+}
 
 .App {
   text-align: center;

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,19 @@
+.layer-answers {
+  stroke: red;
+  fill: red;
+}
+
+.layer-question {
+  stroke: green;
+  fill: green;
+}
+
+.layer-question:hover {
+    stroke: blue;
+    fill: blue;
+}
+
+
 .App {
   text-align: center;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,70 @@ import TaskList from 'views/task_list/components/TaskList'
 import logo from './logo.svg'
 import './App.css'
 
+import Vex from 'vexflow';
+
 class App extends Component {
+  componentDidMount() {
+    var VF = Vex.Flow;
+
+    // Create an SVG renderer and attach it to the DIV element named "boo".
+    var div = document.getElementById("music")
+    var renderer = new VF.Renderer(div, VF.Renderer.Backends.SVG);
+    renderer.resize(500, 500);
+    var context = renderer.getContext();
+    var tickContext = new VF.TickContext();
+
+    // Create a stave of width 10000 at position 10, 40 on the canvas.
+    var stave = new VF.Stave(10, 10, 10000)
+    .addClef('treble');
+
+    // Connect it to the rendering context and draw!
+    stave.setContext(context).draw();
+
+    var question = [
+      new VF.StaveNote({ keys: ['f/4'], stem_direction: -1, duration: '4' }),
+      new VF.StaveNote({ keys: ['e/4'], stem_direction: 1, duration: '4' }),
+    ];
+
+    var answer = [
+      new VF.StaveNote({ keys: ['a/4'], stem_direction: -1, duration: '4' }),
+      new VF.StaveNote({ keys: ['g/4'], stem_direction: 1, duration: '4' }),
+    ];
+
+    // Connect it to the rendering context and draw!
+
+    context.attributes.fill = null
+    context.attributes.stroke = null
+
+    tickContext.addTickable(question[0])
+    tickContext.addTickable(question[1])
+    tickContext.addTickable(answer[0])
+    tickContext.addTickable(answer[1])
+    question[0].setContext(context).setStave(stave)
+    question[1].setContext(context).setStave(stave)
+    answer[0].setContext(context).setStave(stave)
+    answer[1].setContext(context).setStave(stave)
+
+    const visibleNoteGroups = [];
+
+    const questionLayer = context.openGroup();
+    visibleNoteGroups.push(questionLayer);
+    question[0].draw();
+    tickContext.preFormat().setX(80);
+    question[1].draw();
+    context.closeGroup();
+    questionLayer.classList.add('layer-question');
+
+    const answerLayer = context.openGroup();
+    visibleNoteGroups.push(answerLayer);
+    tickContext.preFormat().setX(40);
+    answer[0].draw();
+    tickContext.preFormat().setX(120);
+    answer[1].draw();
+    context.closeGroup();
+    answerLayer.classList.add('layer-answers');
+  }
+
   render(): React.Element<any> {
     return (
       <div className="App">
@@ -18,6 +81,7 @@ class App extends Component {
         <p className="App-intro">
           To get started, edit <code>src/App.js</code> and save to reload.
         </p>
+        <div id="music"></div>
         <TaskButtons />
         <TaskList />
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import logo from './logo.svg'
 import './App.css'
 
 import Vex from 'vexflow';
+import SpaceHighlighting from './SpaceHighlighting';
 
 class App extends Component {
   componentDidMount() {
@@ -28,13 +29,23 @@ class App extends Component {
     stave.setContext(context).draw();
 
     var question = [
-      new VF.StaveNote({ keys: ['f/4'], stem_direction: -1, duration: '4' }),
+      new VF.StaveNote({ keys: ['c/4'], stem_direction: 1, duration: '4' }),
       new VF.StaveNote({ keys: ['e/4'], stem_direction: 1, duration: '4' }),
     ];
 
     var answer = [
       new VF.StaveNote({ keys: ['a/4'], stem_direction: -1, duration: '4' }),
       new VF.StaveNote({ keys: ['g/4'], stem_direction: 1, duration: '4' }),
+      new VF.GhostNote({ duration: '4' }),
+    ];
+
+    var highlight = [
+      new SpaceHighlighting({ duration: '4' }),
+      new SpaceHighlighting({ duration: '4' }),
+      new SpaceHighlighting({ duration: '4' }),
+      new SpaceHighlighting({ duration: '4' }),
+      new SpaceHighlighting({ duration: '4' }),
+      new SpaceHighlighting({ duration: '4' }),
     ];
 
     // Connect it to the rendering context and draw!
@@ -46,10 +57,25 @@ class App extends Component {
     tickContext.addTickable(question[1])
     tickContext.addTickable(answer[0])
     tickContext.addTickable(answer[1])
+    tickContext.addTickable(highlight[0])
+    tickContext.addTickable(highlight[1])
+    tickContext.addTickable(highlight[2])
+    tickContext.addTickable(highlight[3])
+    tickContext.addTickable(highlight[4])
+    tickContext.addTickable(highlight[5])
     question[0].setContext(context).setStave(stave)
     question[1].setContext(context).setStave(stave)
     answer[0].setContext(context).setStave(stave)
     answer[1].setContext(context).setStave(stave)
+
+
+
+    highlight[0].setContext(context).setStave(stave)
+    highlight[1].setContext(context).setStave(stave)
+    highlight[2].setContext(context).setStave(stave)
+    highlight[3].setContext(context).setStave(stave)
+    highlight[4].setContext(context).setStave(stave)
+    highlight[5].setContext(context).setStave(stave)
 
     const visibleNoteGroups = [];
 
@@ -69,6 +95,23 @@ class App extends Component {
     answer[1].draw();
     context.closeGroup();
     answerLayer.classList.add('layer-answers');
+
+    const highlightLayer = context.openGroup();
+    visibleNoteGroups.push(highlightLayer);
+    tickContext.preFormat().setX(40);
+    highlight[0].draw();
+    tickContext.preFormat().setX(80);
+    highlight[1].draw();
+    tickContext.preFormat().setX(120);
+    highlight[2].draw();
+    tickContext.preFormat().setX(160);
+    highlight[3].draw();
+    tickContext.preFormat().setX(200);
+    highlight[4].draw();
+    tickContext.preFormat().setX(240);
+    highlight[5].draw();
+    context.closeGroup();
+    highlightLayer.classList.add('layer-highlight');
   }
 
   render(): React.Element<any> {

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ class App extends Component {
 
     // Create a stave of width 10000 at position 10, 40 on the canvas.
     var stave = new VF.Stave(10, 10, 10000)
-    .addClef('treble');
+    .addClef('treble')
 
     // Connect it to the rendering context and draw!
     stave.setContext(context).draw();

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import './App.css'
 
 import Vex from 'vexflow';
 import SpaceHighlighting from './SpaceHighlighting';
+import AnswerOptions from './AnswerOptions';
 
 class App extends Component {
   componentDidMount() {
@@ -45,7 +46,7 @@ class App extends Component {
       new SpaceHighlighting({ duration: '4' }),
       new SpaceHighlighting({ duration: '4' }),
       new SpaceHighlighting({ duration: '4' }),
-      new SpaceHighlighting({ duration: '4' }),
+      new AnswerOptions({ duration: '4' })
     ];
 
     // Connect it to the rendering context and draw!

--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,7 @@ class App extends Component {
       new SpaceHighlighting({ duration: '4' }),
       new SpaceHighlighting({ duration: '4' }),
       new SpaceHighlighting({ duration: '4' }),
-      new SpaceHighlighting({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
       new AnswerOptions({ duration: '4' })
     ];
 
@@ -113,6 +113,8 @@ class App extends Component {
     highlight[5].draw();
     context.closeGroup();
     highlightLayer.classList.add('layer-highlight');
+
+    highlight[4].remove();
   }
 
   render(): React.Element<any> {

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,9 @@ class App extends Component {
   componentDidMount() {
     var VF = Vex.Flow;
 
+    var start, end;
+    start = +new Date();
+
     // Create an SVG renderer and attach it to the DIV element named "boo".
     var div = document.getElementById("music")
     var renderer = new VF.Renderer(div, VF.Renderer.Backends.SVG);
@@ -41,12 +44,16 @@ class App extends Component {
     ];
 
     var highlight = [
-      new SpaceHighlighting({ duration: '4' }),
-      new SpaceHighlighting({ duration: '4' }),
-      new SpaceHighlighting({ duration: '4' }),
-      new SpaceHighlighting({ duration: '4' }),
       new AnswerOptions({ duration: '4' }),
-      new AnswerOptions({ duration: '4' })
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
+      new AnswerOptions({ duration: '4' }),
     ];
 
     // Connect it to the rendering context and draw!
@@ -64,6 +71,10 @@ class App extends Component {
     tickContext.addTickable(highlight[3])
     tickContext.addTickable(highlight[4])
     tickContext.addTickable(highlight[5])
+    tickContext.addTickable(highlight[6])
+    tickContext.addTickable(highlight[7])
+    tickContext.addTickable(highlight[8])
+    tickContext.addTickable(highlight[9])
     question[0].setContext(context).setStave(stave)
     question[1].setContext(context).setStave(stave)
     answer[0].setContext(context).setStave(stave)
@@ -77,6 +88,10 @@ class App extends Component {
     highlight[3].setContext(context).setStave(stave)
     highlight[4].setContext(context).setStave(stave)
     highlight[5].setContext(context).setStave(stave)
+    highlight[6].setContext(context).setStave(stave)
+    highlight[7].setContext(context).setStave(stave)
+    highlight[8].setContext(context).setStave(stave)
+    highlight[9].setContext(context).setStave(stave)
 
     const visibleNoteGroups = [];
 
@@ -111,10 +126,22 @@ class App extends Component {
     highlight[4].draw();
     tickContext.preFormat().setX(240);
     highlight[5].draw();
+    tickContext.preFormat().setX(280);
+    highlight[6].draw();
+    tickContext.preFormat().setX(320);
+    highlight[7].draw();
+    tickContext.preFormat().setX(360);
+    highlight[8].draw();
+    tickContext.preFormat().setX(400);
+    highlight[9].draw();
     context.closeGroup();
     highlightLayer.classList.add('layer-highlight');
 
     highlight[4].remove();
+
+    end = +new Date();
+    var diff = end - start;
+    console.log(diff);
   }
 
   render(): React.Element<any> {

--- a/src/SpaceHighlighting.js
+++ b/src/SpaceHighlighting.js
@@ -1,0 +1,42 @@
+import Vex from 'vexflow';
+import { Flow } from 'vexflow';
+var {
+  GhostNote
+} = Flow;
+
+console.log(Vex);
+console.log(Flow);
+
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+//
+// ## Description
+
+export default class SpaceHighlighting extends GhostNote {
+  isRest() { return true; }
+
+  drawRect() {
+    console.log(this);
+    var rect = this.context.rect(this.tickContext.x, 40, 40, 60);
+    this.context.stroke('red')
+
+  }
+
+  draw() {
+    if (!this.context) {
+      throw new Vex.RERR('NoCanvasContext', "Can't draw without a canvas context.");
+    }
+    if (!this.stave) {
+      throw new Vex.RERR('NoStave', "Can't draw without a stave.");
+    }
+    if (this.ys.length === 0) {
+      throw new Vex.RERR('NoYValues', "Can't draw note without Y values.");
+    }
+
+    this.setAttribute('el', this.context.openGroup('highlighting', this.getAttribute('id')));
+    this.drawRect();
+    this.context.closeGroup();
+    this.setRendered();
+
+    console.log('draw')
+  }
+}

--- a/src/SpaceHighlighting.js
+++ b/src/SpaceHighlighting.js
@@ -1,24 +1,17 @@
 import Vex from 'vexflow';
 import { Flow } from 'vexflow';
-var {
-  GhostNote
-} = Flow;
+var { GhostNote } = Flow;
 
-console.log(Vex);
-console.log(Flow);
-
-// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
-//
-// ## Description
+import SvgDrawing from './SvgDrawing';
 
 export default class SpaceHighlighting extends GhostNote {
-  isRest() { return true; }
-
   drawRect() {
-    console.log(this);
-    var rect = this.context.rect(this.tickContext.x, 40, 40, 60);
-    this.context.stroke('red')
+    var rect = new SvgDrawing(this.context)
+      .rect(this.tickContext.x, 40, 40, 60);
 
+    rect.addEventListener("click", function(e) {
+      console.log('clicked')
+    })
   }
 
   draw() {
@@ -32,11 +25,19 @@ export default class SpaceHighlighting extends GhostNote {
       throw new Vex.RERR('NoYValues', "Can't draw note without Y values.");
     }
 
-    this.setAttribute('el', this.context.openGroup('highlighting', this.getAttribute('id')));
+    var group = this.context.openGroup('highlighting', this.getAttribute('id'));
+    this.setAttribute('el', group);
+
     this.drawRect();
+    // grect.mouseover(function(e) {
+    //     rect.attr('fill', 'red');
+    // }).mouseout(function(e) {
+    //     rect.attr('fill', 'white');
+    // }).mouseup(function(e) {
+    //     alert("clicked");
+    // });
+
     this.context.closeGroup();
     this.setRendered();
-
-    console.log('draw')
   }
 }

--- a/src/SvgDrawing.js
+++ b/src/SvgDrawing.js
@@ -1,0 +1,35 @@
+import Vex from 'vexflow';
+
+export default class SvgDrawing {
+  constructor(context) {
+    this.context = context;
+  }
+
+  rect(x, y, width, height, attributes) {
+    if (height < 0) {
+      y += height;
+      height *= -1;
+    }
+
+    const rectangle = this.context.create('rect');
+    if (typeof attributes === 'undefined') {
+      attributes = {
+        fill: 'none',
+        'stroke-width': this.lineWidth,
+        stroke: 'black',
+      };
+    }
+
+    Vex.Merge(attributes, {
+      x,
+      y,
+      width,
+      height,
+    });
+
+    this.context.applyAttributes(rectangle, attributes);
+
+    this.context.add(rectangle);
+    return rectangle;
+  }
+}


### PR DESCRIPTION
I did some spikes with VexFlow and so far I was able to:

- [x] bypass validation of the rendered notation (https://jsfiddle.net/gs4v6k6d/153/), so we can add notes without restrictions, 

- [x] able to start creating layers of notes (for questions, answers, etc)

- [x] add ghost notes for spacing

- [x] add some basic hover/interactivity. This basic interactivity leads me to believe that it should be easy to do more complex things, since I can control the classes/html of the generated svg object, although I am not sure yet. One example is at https://jsfiddle.net/gs4v6k6d/157/.

- [x] add highlighting zones where user would insert notes

- [x] add click events to highlighting zones

- [x] add a specific note to a highlighting zone

- [ ] render a note outside a staff (?) may need this to display all possible notes the user will select and add to the staff 

- [x] render music sheet not elements independently for render speed. 
   >render speed, in the sense that we probably don't want to re-render the whole system for every new note. I think this can be answered by seeing if the staff itself can be hidden, either in code or in CSS. If so, each layer could have its own rendering, keeping things a bit more React